### PR TITLE
Fixed typo present in defaults/main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,8 +30,8 @@
 #   - mesh: filename
 #     remote_url: url
 #     remote_dir: /tmp
-#     remote_agents: "{{ groups['ps-maddash'] }}
-#       + {{ groups['ps-toolkits'] }}
-#       + {{ groups['ps-testpoints'] }}"
+#     remote_agents: "{{ groups['ps_maddash'] }}
+#       + {{ groups['ps_toolkit'] }}
+#       + {{ groups['ps_testpoint'] }}"
 #     remote_configure_archives: True
 perfsonar_psconfig_publish_meshes: []


### PR DESCRIPTION
There is a mismatch between group definition in hosts/inventory file in
here:
https://raw.githubusercontent.com/perfsonar/ansible-playbook-perfsonar/master/inventory/hosts

[ps_toolkit]
[ps_maddash]
[ps_testpoint]

and in defaults/main.yml file:

